### PR TITLE
Add VirtualCube support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Takes an arbitrary number of schema fragments containing:
 - schema (containing cubes and shared dims)
 - shared dims
 - cubes
+- virtual cubes
 
 and then concatenates the fragement sections in the correct
 order (schema wraps shared dims and then cubes, in that order).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ const SCHEMA_TAG_OPEN: &str = r#"<Schema name=""#;
 const SCHEMA_TAG_CLOSE: &str = r#"</Schema>"#;
 const CUBE_TAG_OPEN: &str = "<Cube";
 const DIM_TAG_OPEN: &str = "<Dimension";
+const VIRTUALCUBE_TAG_OPEN: &str = r#"<VirtualCube"#;
 
 
 /// Struct to hold the results of parsing
@@ -60,6 +61,7 @@ pub struct Fragment<'a> {
     schema_name: Option<&'a str>,
     shared_dims: Option<&'a str>,
     cubes: Option<&'a str>,
+    virtual_cubes: Option<&'a str>,
 }
 
 impl<'a> Fragment<'a> {
@@ -135,17 +137,31 @@ impl<'a> Fragment<'a> {
             })
     }
 
+    // Get virtual cubes from one fragment
+    fn get_virtual_cubes(fragment: &'a str) -> Option<&'a str> {
+        fragment.find(VIRTUALCUBE_TAG_OPEN)
+            .and_then(|i| {
+                fragment[i..]
+                    .find(SCHEMA_TAG_CLOSE).or(Some(fragment.len()-i))
+                    .and_then(|j| {
+                        fragment.get(i..i+j)
+                    })
+            })
+    }
+
     pub fn process_fragment(fragment: &'a str) -> Fragment<'a> {
         // TODO make this work with string parse fn?
 
         let schema_name = Fragment::get_schema_name(fragment);
         let shared_dims = Fragment::get_shared_dims(fragment);
         let cubes = Fragment::get_cubes(fragment);
+        let virtual_cubes = Fragment::get_virtual_cubes(fragment);
 
         Fragment {
             schema_name: schema_name,
             shared_dims: shared_dims,
             cubes: cubes,
+            virtual_cubes: virtual_cubes,
         }
     }
 }
@@ -201,6 +217,11 @@ pub fn fragments_to_schema(fragments: &[String]) -> Result<String> {
     for frag in &fragments {
         if let Some(cubes) = frag.cubes {
             final_schema.push_str(cubes);
+        }
+    }
+    for frag in &fragments {
+        if let Some(virtual_cubes) = frag.virtual_cubes {
+            final_schema.push_str(virtual_cubes);
         }
     }
 
@@ -266,7 +287,7 @@ mod tests {
 
     #[test]
     fn test_get_cubes() {
-        let fragment = r#"<Cube name="a"></Cube>"#;
+        let fragment = r#"<Cube name="a"></Cube><VirtualCube name="vc1"></VirtualCube>"#;
         assert_eq!(
             Fragment::get_cubes(fragment),
             Some(r#"<Cube name="a"></Cube>"#)
@@ -276,6 +297,21 @@ mod tests {
         assert_eq!(
             Fragment::get_cubes(fragment),
             Some(r#"<Cube name="a"></Cube>"#)
+        );
+    }
+
+    #[test]
+    fn test_get_virtual_cubes() {
+        let fragment = r#"<VirtualCube name="vc1"></VirtualCube>"#;
+        assert_eq!(
+            Fragment::get_virtual_cubes(fragment),
+            Some(r#"<VirtualCube name="vc1"></VirtualCube>"#)
+        );
+
+        let fragment = r#"<Schema name="s1"><VirtualCube name="vc1"></VirtualCube></Schema>"#;
+        assert_eq!(
+            Fragment::get_virtual_cubes(fragment),
+            Some(r#"<VirtualCube name="vc1"></VirtualCube>"#)
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,13 +318,14 @@ mod tests {
     #[test]
     fn test_process_fragment() {
         let fragment = r#"<Schema name="testname">
-            <Dimension name="shareddim"></Dimension><Cube name="testcube"><Dimension name="inner"></Dimension></Cube><Cube name="a"></Cube></Schema>"#;
+            <Dimension name="shareddim"></Dimension><Cube name="testcube"><Dimension name="inner"></Dimension></Cube><Cube name="a"></Cube><VirtualCube name="testvirtualcube"><Dimension name="inner_virtual"></Dimension></VirtualCube><VirtualCube name="a"></VirtualCube></Schema>"#;
         assert_eq!(
             Fragment::process_fragment(fragment),
             Fragment {
                 schema_name: Some("testname"),
                 shared_dims: Some(r#"<Dimension name="shareddim"></Dimension>"#),
                 cubes: Some(r#"<Cube name="testcube"><Dimension name="inner"></Dimension></Cube><Cube name="a"></Cube>"#),
+                virtual_cubes: Some(r#"<VirtualCube name="testvirtualcube"><Dimension name="inner_virtual"></Dimension></VirtualCube><VirtualCube name="a"></VirtualCube>"#),
             }
         );
     }


### PR DESCRIPTION
Is a wip but need some feedback about test. It worked for my example in DataChile but test didn't pass well.
`get_cubes` method also collect `VirtualCube` structures.
```
failures:
    tests::test_get_cubes
    tests::test_process_fragment

test result: FAILED. 7 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
```